### PR TITLE
Fix no target provided errors. Apparently target in “this” context here ...

### DIFF
--- a/addon/helpers/linkify.js
+++ b/addon/helpers/linkify.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import urlRegex from 'ember-linkify/utils/url-regex';
 
-export function linkify(textToLinkify, target) {
-  target = target || "_self";
+export function linkify(textToLinkify, windowTarget) {
+  windowTarget = windowTarget || "_self";
   textToLinkify = Ember.Handlebars.Utils.escapeExpression(textToLinkify);
 
   textToLinkify = textToLinkify.replace(urlRegex(), function (s) {
-    return ' <a href="' + s.trim() + '" target="'+target+'">' + s.trim() + '</a> ';
+    return ' <a href="' + s.trim() + '" target="'+windowTarget+'">' + s.trim() + '</a> ';
   });
 
   return new Ember.Handlebars.SafeString(textToLinkify);


### PR DESCRIPTION
...is some other object so I renamed it to windowTarget. Sorry my bad. Not sure why the tests didn't catch it. But I was getting getting target="[object Object]" when the target was omitted.