### PR TITLE
Fixing a bug when only the bare URL is entered

### DIFF
--- a/addon/helpers/linkify.js
+++ b/addon/helpers/linkify.js
@@ -6,7 +6,13 @@ export function linkify(textToLinkify, windowTarget) {
   textToLinkify = Ember.Handlebars.Utils.escapeExpression(textToLinkify);
 
   textToLinkify = textToLinkify.replace(urlRegex(), function (s) {
-    return ' <a href="' + s.trim() + '" target="'+windowTarget+'">' + s.trim() + '</a> ';
+    var url;
+    if(s.trim().match(/^www\./ig)) {
+      url = '//' + s.trim();
+    } else {
+      url = s.trim();
+    }
+    return ' <a href="' + url + '" target="'+windowTarget+'">' + s.trim() + '</a> ';
   });
 
   return new Ember.Handlebars.SafeString(textToLinkify);

--- a/tests/unit/helpers/linkify-test.js
+++ b/tests/unit/helpers/linkify-test.js
@@ -12,7 +12,7 @@ test('it should turn a url into a link', function(assert) {
 
 test('it should turn a url with www. into a link', function(assert) {
   var result = linkify('www.johnotander.com').toString().trim();
-  assert.equal(result, '<a href="www.johnotander.com" target="_self">www.johnotander.com</a>');
+  assert.equal(result, '<a href="//www.johnotander.com" target="_self">www.johnotander.com</a>');
 });
 
 test('it should escape html', function(assert) {


### PR DESCRIPTION
URL starting with www is not anchored properly, because it's missing the
protocol. Fix adds // in front of those URL's to decide the protocol
automatically, and for the anchor to work properly.