### PR TITLE
Updated README to include 'class' as a valid option. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ For instance, the following will ensure that the `https` scheme is used for the 
 {{linkify 'Link without a scheme: www.foo.com' defaultScheme='https'}}
 ```
 
-##### Also use options to specify attributes you want to add to the generated anchor tags. Currently, "rel" is the only recognized attribute.
+##### Also use options to specify attributes you want to add to the generated anchor tags. Currently, "rel" and "class" are the only recognized attributes.
 
 ```hbs
-{{linkify text rel='nofollow'}}
+{{linkify text rel='nofollow' class='external-link'}}
+```
+
+##### You can also set the target attribute for the generated anchor tag by passing in a second parameter.
+
+```hbs
+{{linkify text target rel='nofollow'}}
 ```
 
 ## Development


### PR DESCRIPTION
And included documentation for passing in a parameter for `target` attr.

Not sure if you had any intention to expose this in the documentation, or if you're just playing around with some options. But I saw this [issue](https://github.com/johnotander/ember-linkify/issues/24) and I thought I would just go ahead and do it.