### PR TITLE
Updated url-regex to accommodate space delimited list of URLs

### DIFF
--- a/addon/helpers/linkify.js
+++ b/addon/helpers/linkify.js
@@ -26,7 +26,7 @@ export function linkify( params, options ) {
       displayText = shortenUrl( displayText, options.urlLength );
     }
 
-    return ` <a href="${url}" target="${windowTarget}"${sharedAttributes}>${displayText}</a> `;
+    return `<a href="${url}" target="${windowTarget}"${sharedAttributes}>${displayText}</a>`;
   });
 
   return Ember.String.htmlSafe(textToLinkify);

--- a/addon/utils/url-regex.js
+++ b/addon/utils/url-regex.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 // URL regex courtesy of https://github.com/kevva/url-regex
 function urlRegex () {
-  return /(?:^|\s)(["'])?(?:(?:(?:(?:https?|ftp|\w):)?\/\/)|(?:www.))(?:\S+(?::\S*)?@)?(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?\1(?:$|\s)/ig;
+  return /(["'])?(?:(?:(?:(?:https?|ftp|\w):)?\/\/)|(?:www.))(?:\S+(?::\S*)?@)?(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?\1/ig;
 }
 
 // Shortens the URL and adds three dots to the end

--- a/tests/unit/helpers/linkify-test.js
+++ b/tests/unit/helpers/linkify-test.js
@@ -99,3 +99,8 @@ test('it should turn a url into a link with a class of "amilkey" and a rel of "n
   var result = linkify(["http://emberjs.com/", "_blank"] , options ).toString().trim();
   assert.equal(result , '<a href="http://emberjs.com/" target="_blank" rel="noopener" class="amilkey">http://emberjs.com/</a>' );
 });
+
+test('it should turn a space delimited list of urls into seperate links', function(assert) {
+  var result = linkify(['My link: http://google.com http://bing.com www.altavista.com']).toString().trim();
+  assert.equal(result, 'My link: <a href="http://google.com" target="_self">http://google.com</a> <a href="http://bing.com" target="_self">http://bing.com</a> <a href="//www.altavista.com" target="_self">www.altavista.com</a>');
+});


### PR DESCRIPTION
And added a test to assert new behaviour for multiple URLs in the input string.

Change is basically in the `url-regex` where I removed two non-capturing groups that were looking for spaces before/after the URL pattern. After that I just updated the outputted template. With those two changes, the tests were unchanged and passing.

I didn't look into supporting commas because they are a valid character in a URL string, so I think that is a reasonable compromise.

Refs https://github.com/johnotander/ember-linkify/issues/17